### PR TITLE
Update MiniOmega to make rifleman example work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/src/MiniOmega.jl
+++ b/src/MiniOmega.jl
@@ -1,6 +1,8 @@
 module MiniOmega
 
-export rv, cond
+import Statistics:mean
+
+export rv, cond, Ω, bernoulli, prob, doo
 
 # Please note that since Julia is eager, this implementation differs from our semantics
 
@@ -10,17 +12,22 @@ export rv, cond
 
 "Sample Space Object"
 mutable struct Ω
-  data::Dict{Tuple{Int, Int}, Real}
-  i::Int
+  data::Dict{Int, Real}
+  # i::Int
+end
+
+mutable struct IntervenedΩ
+  data::Dict{Int, Real}
+  intervention::Pair
 end
 
 "ω[j] returns jth value, under whatever random variable it is currently projected to"
-function Base.getindex(ω::Ω, j)
-  if (ω.i, j) in keys(ω.data)
-    ω.data[(ω.i, j)]
+function Base.getindex(ω::Union{Ω, IntervenedΩ}, j)
+  if j in keys(ω.data)
+    ω.data[j]
   else
     val = rand()
-    ω.data[(ω.i, j)] = val
+    ω.data[j] = val
     val
   end
 end
@@ -35,19 +42,49 @@ end
 
 global counter = 0
 
+# distributions section
+function bernoulli(p::Real, idx::Int)
+  return ω -> ω[idx] >= p
+end
+
 "Turn a function `f` into a random variable by giving it a unique id"
 rv(f) = (global counter += 1; RandVar(counter, f))
 
-"Project `ω` to the subspace of `rv`"
-proj(ω::Ω, rv::RandVar) = Ω(ω.data, rv.id)
+# "Project `ω` to the subspace of `rv`"
+# proj(ω::Ω, rv::RandVar) = Ω(ω.data, rv.id)
 
 "Random variable application first projects `ω` to `rv` then applies function"
-(rv::RandVar)(ω::Ω) = rv.f(proj(ω, rv))
+(rv::RandVar)(ω::Ω) = rv.f(ω)
+
+function (rv::RandVar)(ω::IntervenedΩ)
+  if rv == ω.intervention[1]
+    ω.intervention[2]
+  else
+    rv.f(ω)
+  end
+end
 
 "Conditoning evaluates an error if `y` is `false`"
 cond(x::RandVar, y::RandVar) = rv(ω -> y(ω) ? x(ω) : error())
 
+"do operator"
+function doo(x::RandVar, intervention)
+  rv(ω -> x(IntervenedΩ(ω.data, intervention)))
+end
+
 "Rejection Sampling: keeps trying until now errors thrown"
-Base.rand(x::RandVar) = try x(Ω(Dict(), 0)) catch; rand(x) end
+Base.rand(x::RandVar) = try x(Ω(Dict())) catch; rand(x) end
+
+"Return prob that rv is true"
+function prob(x::RandVar, n::Int=1000)
+  samples = [rand(x) for i=1:n]
+  mean(samples)
+end
+
+# override logical 'OR' operator for rvs
+Base.:|(x::RandVar, y::RandVar) = rv((ω -> x(ω) | y(ω)))
+
+# override negation operator for rvs, only for true/false rvs
+Base.:!(x::RandVar) = rv(ω -> !x(ω))
 
 end # module

--- a/test/rifleman.jl
+++ b/test/rifleman.jl
@@ -2,10 +2,10 @@
 using MiniOmega
 using Test
 # The court orders an executiion with probability 0.5
-court_order = rv(bernoulli)
+court_order = rv(bernoulli(0.5, 1))
 
 # With probability 0.5 the rifleman is nervous and fires
-A_nervous = rv(bernoulli)
+A_nervous = rv(bernoulli(0.5, 2))
 
 # Rifleman A and B both fire if the court orders the exectuion
 # Hint: Functions (such as | 'or' ) of random variables are defined pointwise
@@ -25,8 +25,7 @@ alt_dead = doo(dead, riflemanA => false)
 counterfactual_dead = cond(!alt_dead, dead)
 
 # Hint: Use sample average to approximate mean
-p = prob(counterfactual_dead)
-
+p = prob(counterfactual_dead, 10000)
 
 # prob ≈ 0.33
-@test isapprox(p, 0.33, atol = 0.01)
+@test isapprox(p, 0.33, atol = 0.05)


### PR DESCRIPTION
This PR adds the following additions to MiniOmega:

-a bernoulli RV type
-an intervened Omega type, for doing interventions
-the 'do' operator
- additional operations to support the above types

The rifleman.jl test should now fully run